### PR TITLE
Gateway 모듈의 JWT 인증 필터를 구현한다.

### DIFF
--- a/resumarble-gateway/build.gradle.kts
+++ b/resumarble-gateway/build.gradle.kts
@@ -12,6 +12,8 @@ extra["springCloudVersion"] = "2022.0.4"
 dependencies {
 
     implementation("org.springframework.cloud:spring-cloud-starter-gateway")
+    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")
+
     developmentOnly("io.netty:netty-resolver-dns-native-macos:4.1.75.Final") {
         artifact { classifier = "osx-aarch_64" }
     }

--- a/resumarble-gateway/out/production/resources/application.yaml
+++ b/resumarble-gateway/out/production/resources/application.yaml
@@ -1,2 +1,18 @@
 server:
   port: 9000
+
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: resumarble-main
+          uri: https://www.resumarble.site
+          predicates:
+            - Path=/**
+
+external:
+  jwt:
+    secret-key: ENC(lrBnCZFjSWFI5R8i2I/1kd7ePdWgkXfmI4YNvTAvwiC3xNWgiBZmQwD8pr+1Wlh5ADMew1sWh5piKAp6AmjtNW7gdFgEe6bvdAGwsDeIYodiPNfa6GaMFQ==)
+jasypt:
+  encryptor:
+    password: ${JASYPT_PASSWORD}

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/config/JasyptConfig.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/config/JasyptConfig.kt
@@ -1,0 +1,30 @@
+package resumarble.gateway.config
+
+import org.jasypt.encryption.StringEncryptor
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JasyptConfig {
+    @Value("\${jasypt.encryptor.password}")
+    private lateinit var password: String
+
+    @Bean("jasyptStringEncryptor")
+    fun stringEncryptor(): StringEncryptor {
+        val encryptor = PooledPBEStringEncryptor()
+        val config = SimpleStringPBEConfig()
+        config.password = password
+        config.algorithm = "PBEWITHMD5AndDES"
+        config.setKeyObtentionIterations("1000")
+        config.setPoolSize("1")
+        config.providerName = "SunJCE"
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator")
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator")
+        config.stringOutputType = "base64"
+        encryptor.setConfig(config)
+        return encryptor
+    }
+}

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/config/WebFluxConfig.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/config/WebFluxConfig.kt
@@ -1,4 +1,4 @@
-package resumarble.config
+package resumarble.gateway.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.config.EnableWebFlux

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/filter/JwtAuthenticationGatewayFilter.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/filter/JwtAuthenticationGatewayFilter.kt
@@ -1,0 +1,63 @@
+package resumarble.gateway.filter
+
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import resumarble.gateway.jwt.JwtException
+import resumarble.gateway.jwt.JwtVerifier
+
+@Component
+class JwtAuthenticationGatewayFilter(
+    private val jwtVerifier: JwtVerifier
+) : AbstractGatewayFilterFactory<JwtAuthenticationGatewayFilter.Config>(Config::class.java) {
+
+    data class Config(
+        val name: String
+    )
+
+    override fun apply(config: Config): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            val token = exchange.request.headers[HttpHeaders.AUTHORIZATION]?.get(0)?.substring(7)
+            val decodedJwt = jwtVerifier.verify(token!!)
+            addAuthorizationHeader(exchange, decodedJwt.claims["userId"].toString())
+            chain.filter(exchange)
+        }
+    }
+
+    private fun addAuthorizationHeader(exchange: ServerWebExchange, userId: String) {
+        exchange.mutate().request(
+            exchange.request.mutate().header("X-Authorization-id", userId).build()
+        ).build()
+    }
+
+    @Bean
+    fun tokenValidation(): ErrorWebExceptionHandler {
+        return JwtExceptionHandler()
+    }
+
+    class JwtExceptionHandler : ErrorWebExceptionHandler {
+        private fun getErrorCode(errorCode: Int) = "에러 코드: $errorCode"
+
+        override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> {
+            var errorCode = 500
+            when (ex) {
+                is JwtException -> {
+                    errorCode = 401
+                }
+
+                is IllegalArgumentException -> {
+                    errorCode = 400
+                }
+            }
+            val bytes = getErrorCode(errorCode).toByteArray()
+            val buffer = exchange.response.bufferFactory().wrap(bytes)
+            return exchange.response.writeWith(Flux.just(buffer))
+        }
+    }
+}

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/filter/RedirectGlobalFilter.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/filter/RedirectGlobalFilter.kt
@@ -1,0 +1,23 @@
+package resumarble.gateway.filter
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain
+import org.springframework.cloud.gateway.filter.GlobalFilter
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import java.net.URI
+
+@Component
+class RedirectGlobalFilter : GlobalFilter {
+    override fun filter(exchange: ServerWebExchange?, chain: GatewayFilterChain?): Mono<Void>? {
+        val request = exchange?.request
+        if ("/resumarble" == request?.uri?.path) {
+            val response = exchange.response
+            response.statusCode = HttpStatus.PERMANENT_REDIRECT
+            response.headers.location = URI.create("https://www.resumarble.site")
+            return Mono.empty()
+        }
+        return chain!!.filter(exchange)
+    }
+}

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/jwt/JwtException.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/jwt/JwtException.kt
@@ -1,0 +1,5 @@
+package resumarble.gateway.jwt
+
+class JwtException(
+    override val message: String
+) : RuntimeException(message)

--- a/resumarble-gateway/src/main/kotlin/resumarble/gateway/jwt/JwtVerifier.kt
+++ b/resumarble-gateway/src/main/kotlin/resumarble/gateway/jwt/JwtVerifier.kt
@@ -1,0 +1,24 @@
+package resumarble.gateway.jwt
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class JwtVerifier {
+
+    @Value("\${external.jwt.secret-key}")
+    private lateinit var secretKey: String
+
+    fun verify(token: String): DecodedJWT {
+        try {
+            return JWT.require(Algorithm.HMAC256(secretKey))
+                .build()
+                .verify(token)
+        } catch (e: Exception) {
+            throw JwtException("토큰이 유효하지 않습니다.")
+        }
+    }
+}

--- a/resumarble-gateway/src/main/resources/application.yaml
+++ b/resumarble-gateway/src/main/resources/application.yaml
@@ -1,2 +1,18 @@
 server:
   port: 9000
+
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: resumarble-main
+          uri: https://www.resumarble.site
+          predicates:
+            - Path=/**
+
+external:
+  jwt:
+    secret-key: ENC(lrBnCZFjSWFI5R8i2I/1kd7ePdWgkXfmI4YNvTAvwiC3xNWgiBZmQwD8pr+1Wlh5ADMew1sWh5piKAp6AmjtNW7gdFgEe6bvdAGwsDeIYodiPNfa6GaMFQ==)
+jasypt:
+  encryptor:
+    password: ${JASYPT_PASSWORD}


### PR DESCRIPTION
# Motivation:

현재까지 별도의 auth 서버를 구현하기엔 오버 엔지니어링이라고 판단되어 Gateway에서 인증까지 담당하도록 한다.

# Modifications:

- JWT 인증 방식의 필터를 구현한다.
- 메인 서버 Redirect 필터를 구현한다.
- JASYPT 암호화로 보안을 유지한다.

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

# Closes #. (If this resolves the issue.)
* Describe the consequences that a user will face after this PR is merged.
