### PR TITLE
마이 페이지 조회시 예상 질문과 답변이 모두 삭제된 prediction은 노출되지 않는다.

### DIFF
--- a/resumarble-core/src/main/kotlin/resumarble/core/domain/prediction/application/service/PredictionQueryService.kt
+++ b/resumarble-core/src/main/kotlin/resumarble/core/domain/prediction/application/service/PredictionQueryService.kt
@@ -16,21 +16,23 @@ class PredictionQueryService(
 
     override fun getPredictionByUserId(userId: Long, page: Pageable): List<PredictionResponse> {
         findPredictionPort.findPredictionsByUserId(userId, page)?.let { predictions ->
-            return predictions.map {
-                PredictionResponse(
-                    predictionId = it.predictionId,
-                    job = it.job.jobTitleKr,
-                    category = it.category.value,
-                    questionAndAnswer = it.questionAndAnswer.map { questionAndAnswer ->
-                        QuestionAndAnswerResponse(
-                            qaId = questionAndAnswer.id,
-                            question = questionAndAnswer.question.value,
-                            answer = questionAndAnswer.answer.value
-                        )
-                    },
-                    createdDate = it.createdDate
-                )
-            }
+            return predictions
+                .filter { it.questionAndAnswer.isNotEmpty() }
+                .map { prediction ->
+                    PredictionResponse(
+                        predictionId = prediction.predictionId,
+                        job = prediction.job.jobTitleKr,
+                        category = prediction.category.value,
+                        questionAndAnswer = prediction.questionAndAnswer.map { questionAndAnswer ->
+                            QuestionAndAnswerResponse(
+                                qaId = questionAndAnswer.id,
+                                question = questionAndAnswer.question.value,
+                                answer = questionAndAnswer.answer.value
+                            )
+                        },
+                        createdDate = prediction.createdDate
+                    )
+                }
         } ?: return emptyList()
     }
 }


### PR DESCRIPTION
# Motivation:
QuestionAndAnswer를 개별적으로 삭제할 수 있지만,
모그룹은 Prediction의 경우 QuestionAndAnswer가 0이 되어도 삭제되지 않는 문제가 발생한다.

# Modifications:

현재로써는 filter를 이용해 questionAndAnswer가 0인 경우에는 노출하지 않는다.

* List the modifications you've made in detail.

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

그러나 이미 페이지대로 조회했을 때,10개에서 필터 처리 후 7개만 응답으로 내려가는 문제가 발생한다.

# Closes #. (If this resolves the issue.)
* Describe the consequences that a user will face after this PR is merged.
