### PR TITLE
면접 예상 질문 테이블 구조를 변경하고, 페이지네이션을 포함한 조회 로직을 구현한다.

### DIFF
--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/InterviewQuestionDto.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/InterviewQuestionDto.kt
@@ -27,10 +27,11 @@ data class PredictionResponse(
     val question: String,
     val bestAnswer: String
 ) {
-    fun toCommand(userId: Long, category: Category): SaveInterviewQuestionCommand {
+    fun toCommand(userId: Long, category: Category, job: String): SaveInterviewQuestionCommand {
         return SaveInterviewQuestionCommand(
             userId = userId,
             category = Category.fromValue(category.value),
+            job = job,
             question = question,
             answer = bestAnswer
         )
@@ -40,6 +41,7 @@ data class PredictionResponse(
 data class SaveInterviewQuestionCommand(
     val userId: Long,
     val category: Category,
+    val job: String,
     val question: String,
     val answer: String
 ) {
@@ -47,6 +49,7 @@ data class SaveInterviewQuestionCommand(
         return InterviewQuestion(
             userId = userId,
             category = category,
+            job = job,
             question = question,
             answer = answer
         )

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/InterviewQuestionReader.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/InterviewQuestionReader.kt
@@ -1,0 +1,16 @@
+package resumarble.reactor.domain.interview.application
+
+import org.springframework.data.domain.Pageable
+import reactor.core.publisher.Flux
+import resumarble.reactor.domain.interview.domain.InterviewQuestion
+import resumarble.reactor.domain.interview.infrastructure.InterviewQuestionRepository
+import resumarble.reactor.global.annotation.Reader
+
+@Reader
+class InterviewQuestionReader(
+    private val interviewQuestionRepository: InterviewQuestionRepository
+) {
+    fun getInterviewQuestions(userId: Long, page: Pageable): Flux<InterviewQuestion> {
+        return interviewQuestionRepository.findAllByUserId(userId, page)
+    }
+}

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/ResponseDto.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/application/ResponseDto.kt
@@ -1,0 +1,37 @@
+package resumarble.reactor.domain.interview.application
+
+import resumarble.reactor.domain.interview.domain.Category
+import resumarble.reactor.domain.interview.domain.InterviewQuestion
+import java.time.LocalDateTime
+
+data class FindInterviewQuestionResponse(
+    val userId: Long,
+    val questionAndAnswer: QuestionAndAnswer,
+    val job: String,
+    val category: Category,
+    val isVisited: Boolean,
+    val createdDate: LocalDateTime
+) {
+
+    companion object {
+        @JvmStatic
+        fun from(interviewQuestion: InterviewQuestion): FindInterviewQuestionResponse {
+            return FindInterviewQuestionResponse(
+                userId = interviewQuestion.userId,
+                questionAndAnswer = QuestionAndAnswer(
+                    question = interviewQuestion.question,
+                    answer = interviewQuestion.answer
+                ),
+                job = interviewQuestion.job,
+                category = interviewQuestion.category,
+                isVisited = interviewQuestion.isVisible,
+                createdDate = interviewQuestion.createdAt
+            )
+        }
+    }
+}
+
+data class QuestionAndAnswer(
+    val question: String,
+    val answer: String
+)

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/controller/InterviewQuestionApi.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/controller/InterviewQuestionApi.kt
@@ -1,9 +1,12 @@
 package resumarble.reactor.domain.interview.controller
 
+import org.springframework.data.domain.PageRequest
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import resumarble.reactor.domain.interview.application.InterviewQuestionFacade
 
@@ -18,6 +21,16 @@ class InterviewQuestionApi(
         @RequestBody request: InterviewQuestionRequest,
         @RequestHeader(X_AUTHORIZATION_ID, defaultValue = "0") userId: String
     ) = interviewQuestionFacade.generateInterviewQuestions(request.toCommandList(userId.toLong()))
+
+    @GetMapping
+    fun readInterviewQuestion(
+        @RequestParam(
+            defaultValue = "0"
+        ) page: Int,
+        @RequestHeader(X_AUTHORIZATION_ID) userId: String
+    ) {
+        interviewQuestionFacade.readInterviewQuestions(userId.toLong(), PageRequest.of(page, 10))
+    }
 
     companion object {
         private const val X_AUTHORIZATION_ID = "X-Authorization-Id"

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/controller/InterviewQuestionApi.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/controller/InterviewQuestionApi.kt
@@ -1,12 +1,14 @@
 package resumarble.reactor.domain.interview.controller
 
 import org.springframework.data.domain.PageRequest
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import resumarble.reactor.domain.interview.application.InterviewQuestionFacade
 
@@ -23,14 +25,11 @@ class InterviewQuestionApi(
     ) = interviewQuestionFacade.generateInterviewQuestions(request.toCommandList(userId.toLong()))
 
     @GetMapping
+    @ResponseStatus(HttpStatus.OK)
     fun readInterviewQuestion(
-        @RequestParam(
-            defaultValue = "0"
-        ) page: Int,
+        @RequestParam(defaultValue = "0") page: Int,
         @RequestHeader(X_AUTHORIZATION_ID) userId: String
-    ) {
-        interviewQuestionFacade.readInterviewQuestions(userId.toLong(), PageRequest.of(page, 10))
-    }
+    ) = interviewQuestionFacade.readInterviewQuestions(userId.toLong(), PageRequest.of(page, 10))
 
     companion object {
         private const val X_AUTHORIZATION_ID = "X-Authorization-Id"

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/domain/InterviewQuestion.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/domain/InterviewQuestion.kt
@@ -20,6 +20,8 @@ class InterviewQuestion(
     @Column("category")
     val category: Category,
 
+    val job: String,
+
     @Column("question")
     val question: String,
 

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/infrastructure/InterviewQuestionRepository.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/domain/interview/infrastructure/InterviewQuestionRepository.kt
@@ -1,6 +1,12 @@
 package resumarble.reactor.domain.interview.infrastructure
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.r2dbc.repository.R2dbcRepository
+import reactor.core.publisher.Flux
 import resumarble.reactor.domain.interview.domain.InterviewQuestion
 
-interface InterviewQuestionRepository : R2dbcRepository<InterviewQuestion, Long>
+interface InterviewQuestionRepository : R2dbcRepository<InterviewQuestion, Long> {
+    @Query("SELECT * FROM interview_question WHERE user_id = :userId AND is_deleted = FALSE")
+    fun findAllByUserId(userId: Long, page: Pageable): Flux<InterviewQuestion>
+}

--- a/resumarble-reactor/src/main/kotlin/resumarble/reactor/global/annotation/Reader.kt
+++ b/resumarble-reactor/src/main/kotlin/resumarble/reactor/global/annotation/Reader.kt
@@ -1,0 +1,10 @@
+package resumarble.reactor.global.annotation
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Transactional(readOnly = true)
+annotation class Reader


### PR DESCRIPTION
# Motivation:
기존 Prediction의 경우 연관된 QuestionAndAnswer 테이블과의 관계가 조회시 문제가 된다.
QuestionAndAnswer가 모두 삭제된 Prediction이 조회된다.

# Modifications:
테이블 구조를 Prediction -> QuestionAndAnswer에서
InterviewQuestion 하나로 뎁스를 낮추고, 페이지네이션을 통해 조회할 수 있는 기능을 구현한다.

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

# Closes #. (If this resolves the issue.)
* Describe the consequences that a user will face after this PR is merged.
